### PR TITLE
Use Pascal casing for method names in C#

### DIFF
--- a/code/functions.cs
+++ b/code/functions.cs
@@ -1,4 +1,4 @@
-string greet(string name, string day) {
-    return $"Hello {name}, today is {day}.";
-}
-greet("Bob", "Tuesday");
+string Greet(string name, string day) =>
+    $"Hello {name}, today is {day}.";
+
+Greet("Bob", "Tuesday");


### PR DESCRIPTION
Pascal casing is the right naming convention for C# methods.